### PR TITLE
Correzione equivalenza integrale in esempio onda quadra Fourier

### DIFF
--- a/teoriasegnali/fourier.tex
+++ b/teoriasegnali/fourier.tex
@@ -104,7 +104,7 @@ Segnale onda quadra di periodo T durata $\tau$ in fig.\ref*{fig:onda_quadra} \[s
 \end{figure}
 Il segnale è reale pari ($c_k=c_{-k}$), i coefficienti della serie di Fourier si calcolano applicando la formula \ref{eq:serie_fourier_coef}:
 \[\begin{split}c_k&=\frac{1}{T}\intd{-\frac{T}{2}}{\frac{T}{2}}{s(t)\e{-\imath 2\pi\frac{k}{T}t}}{t}
-=\frac{1}{T}\intd{-\frac{T}{2}}{\frac{T}{2}}{\e{-\imath 2\pi\frac{k}{T}t}}{t}
+=\frac{1}{T}\intd{-\frac{\tau}{2}}{\frac{\tau}{2}}{\e{-\imath 2\pi\frac{k}{T}t}}{t}
 =\frac{1}{T}\bound{-\frac{\tau}{2}}{\frac{\tau}{2}}{ \frac{\e{-\imath 2\pi\frac{k}{T}t}}{-\imath 2\pi\frac{k}{T}}}=\\
 &=\frac{1}{\pi k} \frac{-\e{-\imath 2\pi\frac{k}{T}\frac{\tau}{2}}+\e{\imath 2\pi\frac{k}{T}\frac{\tau}{2}}}{\imath 2}
 =\frac{\sen{\pi \tau \frac{k}{T}}}{\pi k}


### PR DESCRIPTION
Nell'esempio 2.1 di pagina 11/12 ("Esempio serie di Fourier di un'onda quadra"), è presente un piccolo errore negli estremi del secondo integrale nel calcolo di c<sub>k</sub>.

Il segnale s(t) ha valore 1 nell'intervallo che va da -τ/2 a +τ/2, e non da -T/2 a T/2. Piccola incongruenza che mi ha lasciato leggermente perplesso, perciò ho voluto contribuire!